### PR TITLE
replaced recursive call with loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,25 +20,25 @@ class ReadableToReadable extends Readable {
     })
 
     const read = async function () {
-      const chunk = input.read()
+      while (true) {
+        const chunk = input.read()
 
-      if (!chunk) {
-        if (done && end) {
-          this.push(null)
-        }
+        if (!chunk) {
+          if (done && end) {
+            this.push(null)
+          }
 
-        if (done) {
-          return true
-        }
+          if (done) {
+            return true
+          }
 
-        await nextLoop()
-      } else {
-        if (!this.push(map(chunk))) {
-          return false
+          await nextLoop()
+        } else {
+          if (!this.push(map(chunk))) {
+            return false
+          }
         }
       }
-
-      return read.call(this)
     }
 
     return read


### PR DESCRIPTION
Replaced recursive `read` call with a while loop to avoid call stack size exceeded errors.